### PR TITLE
start_transaction at the right time

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -119,7 +119,6 @@ impl TxnDispatcher for Dispatcher {
                 {
                     bail!("batch aborted");
                 }
-                ctx.start_transaction();
                 let tx = self.decode_transaction(call, &mut ctx)?;
 
                 #[cfg(feature = "prefetch")]

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -51,6 +51,9 @@ pub mod execute {
 
     /// Execute an Ethereum transaction.
     pub fn tx(call: &DecodedCall, ctx: &mut TxnContext) -> Result<ExecutionResult> {
+        // Notify the context that subsequent mutations are due to this new transaction.
+        ctx.start_transaction();
+
         let txn = &call.transaction;
 
         // If this is a check txn request, return success.


### PR DESCRIPTION
The previous location of [`start_transaction`](https://github.com/oasisprotocol/oasis-core/blob/e83231bf3fdcbced6b6baed6f756bd153e925c84/runtime/src/transaction/context.rs#L45) caused all of the transactions' tags to be immediately pushed onto the tag stack. Unfortunately, [only the last one](https://github.com/oasisprotocol/oasis-core/blob/e83231bf3fdcbced6b6baed6f756bd153e925c84/runtime/src/transaction/context.rs#L75) is modified, which led to only the final txn in the block being indexed. This PR fixes that by starting the txn right before it's executed.

There are no integration tests other than staging not failing. If we wanted one, however, it'd be to `make run-gateway` and then set up two txn clients, verifying that there are two txns per block. `oasis-net-runner` needs to take the [`maxBatchSize`](https://github.com/oasisprotocol/oasis-core/blob/master/go/oasis-net-runner/fixtures/default.go#L111) as a parameter, though. Alternatively, we could [have the tx clients check if their txs succeeded](https://github.com/oasislabs/transaction-client/pull/21).